### PR TITLE
Fix syntax error, unexpected '=>' (T_DOUBLE_ARROW)

### DIFF
--- a/1-get-users-from-moco.php
+++ b/1-get-users-from-moco.php
@@ -16,7 +16,7 @@ $args = (array) $opts;
 $arg_page = !empty($args['page']) ? $args['page'] : 1;
 $arg_last = !empty($args['last']) ? $args['last'] : 0;
 
-if (!empty($args['batch']) && $args['batch'] => 1 && $args['batch'] <= 1000) {
+if (!empty($args['batch']) && $args['batch'] >= 1 && $args['batch'] <= 1000) {
   $moco->batchSize = (int) $args['batch'];
 }
 


### PR DESCRIPTION
PHP Parse error:  syntax error, unexpected '=>' (T_DOUBLE_ARROW) in /Users/sergii/Development/qs/vcard-scripts/1-get-users-from-moco.php on line 31
