### PR TITLE
Add progress bar with ETA and improve logging.

### DIFF
--- a/1-get-users-from-moco.php
+++ b/1-get-users-from-moco.php
@@ -21,21 +21,21 @@ if (!empty($args['batch']) && $args['batch'] >= 1 && $args['batch'] <= 1000) {
 }
 
 // --- Logger ---
-$logNamePostfix = '-get-users-from-moco'
+$logNamePrefix = $moco->batchSize
  . '-' . $argPage
  . '-' . $argLast
- . '-' . $moco->batchSize;
+ . '-get-users-from-moco-';
 
 // File.
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
 use Monolog\Formatter\LineFormatter;
-$logfile = fopen(__DIR__ . '/log/output' . $logNamePostfix . '.log', "w");
+$logfile = fopen(__DIR__ . '/log/' . $logNamePrefix . 'output.log', "w");
 $logFileStream = new StreamHandler($logfile);
 $logFileStream->setFormatter(new LineFormatter($output . "\n", $dateFormat));
 $log->pushHandler($logFileStream);
 // Warning File.
-$logfile = fopen(__DIR__ . '/log/warning' . $logNamePostfix . '.log', "w");
+$logfile = fopen(__DIR__ . '/log/' . $logNamePrefix . 'warning.log', "w");
 $logFileStream = new StreamHandler($logfile, Logger::WARNING);
 $logFileStream->setFormatter(new LineFormatter($output . "\n", $dateFormat));
 $log->pushHandler($logFileStream);

--- a/1-get-users-from-moco.php
+++ b/1-get-users-from-moco.php
@@ -65,8 +65,9 @@ $moco->profilesEachBatch(function (SimpleXMLElement $profiles) use ($redis, $log
       try {
         $progress->advance();
       } catch (InvalidArgumentException $e) {
-        // Skip.
+        // Ignore current > max error.
       } catch (Exception $e) {
+        // Log other errors.
         $log->error($e);
       }
     }
@@ -78,6 +79,7 @@ $moco->profilesEachBatch(function (SimpleXMLElement $profiles) use ($redis, $log
 
 }, $argPage, $argLast);
 
+// Set 100% when estimated $progressMax turned out to be incorrect.
 if ($progress->getRegistry()->getValue('current') < $progressMax) {
   $progress->update($progressMax);
 }

--- a/1-get-users-from-moco.php
+++ b/1-get-users-from-moco.php
@@ -20,6 +20,26 @@ if (!empty($args['batch']) && $args['batch'] >= 1 && $args['batch'] <= 1000) {
   $moco->batchSize = (int) $args['batch'];
 }
 
+// --- Logger ---
+$logNamePostfix = '-get-users-from-moco'
+ . '-' . $argPage
+ . '-' . $argLast
+ . '-' . $moco->batchSize;
+
+// File.
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+$logfile = fopen(__DIR__ . '/log/output' . $logNamePostfix . '.log', "w");
+$logFileStream = new StreamHandler($logfile);
+$logFileStream->setFormatter(new LineFormatter($output . "\n", $dateFormat));
+$log->pushHandler($logFileStream);
+// Warning File.
+$logfile = fopen(__DIR__ . '/log/warning' . $logNamePostfix . '.log', "w");
+$logFileStream = new StreamHandler($logfile, Logger::WARNING);
+$logFileStream->setFormatter(new LineFormatter($output . "\n", $dateFormat));
+$log->pushHandler($logFileStream);
+
 // --- Progress ---
 $progressCurrent = ($argPage > 1) ? $moco->batchSize * $argPage : 0;
 $progressMax     = ($argLast > 0) ? $moco->batchSize * ($argLast + 1) : 5219581;

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "monolog/monolog": "^1.21",
     "dosomething/mobilecommons-php": "^1.0",
     "deweller/cliopts": "^1.0",
-    "josegonzalez/dotenv": "^2.0"
+    "josegonzalez/dotenv": "^2.0",
+    "guiguiboy/php-cli-progress-bar": "@dev"
   },
   "autoload": {
     "psr-4": {

--- a/config.php
+++ b/config.php
@@ -48,9 +48,9 @@ $logFileStream = new StreamHandler($logfile, Logger::WARNING);
 $logFileStream->setFormatter(new LineFormatter($output . "\n", $dateFormat));
 $log->pushHandler($logFileStream);
 // Console.
-$logConsoleStream = new ErrorLogHandler();
-$logConsoleStream->setFormatter(new LineFormatter($output, $dateFormat));
-$log->pushHandler($logConsoleStream);
+// $logConsoleStream = new ErrorLogHandler();
+// $logConsoleStream->setFormatter(new LineFormatter($output, $dateFormat));
+// $log->pushHandler($logConsoleStream);
 
 
 // --- Objects ---

--- a/config.php
+++ b/config.php
@@ -24,10 +24,10 @@ $moco_config = array(
 use DoSomething\Northstar\NorthstarClient;
 use DoSomething\Vcard\MobileCommonsLoader;
 use Monolog\Logger;
-use Monolog\Handler\StreamHandler;
-use Monolog\Handler\ErrorLogHandler;
+// use Monolog\Handler\StreamHandler;
+// use Monolog\Handler\ErrorLogHandler;
 use Monolog\Processor\PsrLogMessageProcessor;
-use Monolog\Formatter\LineFormatter;
+// use Monolog\Formatter\LineFormatter;
 
 // --- Logger ---
 $log = new Logger('vcard');
@@ -37,16 +37,6 @@ $dateFormat = "Y-m-d H:i:s";
 // the default output format is "[%datetime%] %channel%.%level_name%: %message% %context% %extra%\n"
 $output = "[%datetime%] %level_name%: %message%.";
 
-// File.
-$logfile = fopen(__DIR__ . '/log/output.log', "w");
-$logFileStream = new StreamHandler($logfile);
-$logFileStream->setFormatter(new LineFormatter($output . "\n", $dateFormat));
-$log->pushHandler($logFileStream);
-// Warning File.
-$logfile = fopen(__DIR__ . '/log/warning.log', "w");
-$logFileStream = new StreamHandler($logfile, Logger::WARNING);
-$logFileStream->setFormatter(new LineFormatter($output . "\n", $dateFormat));
-$log->pushHandler($logFileStream);
 // Console.
 // $logConsoleStream = new ErrorLogHandler();
 // $logConsoleStream->setFormatter(new LineFormatter($output, $dateFormat));


### PR DESCRIPTION
Shows progress:

```
5/5 [====================================================>] 100.00% 00:00:00
```

Improves log filename generation  `%batch_size%-%first_page%-%last_page%-get-users-from-moco-%log_level%.log`:

```
$ ls -la log
total 16
drwxr-xr-x  2 sergii  staff  204 Aug 31 19:46 ./
drwxr-xr-x  6 sergii  staff  510 Aug 31 18:44 ../
-rw-r--r--  1 sergii  staff   79 Aug 31 19:46 1-1-1-get-users-from-moco-output.log
-rw-r--r--  1 sergii  staff    0 Aug 31 19:46 1-1-1-get-users-from-moco-warning.log
-rw-r--r--  1 sergii  staff  237 Aug 31 19:46 1-2-4-get-users-from-moco-output.log
-rw-r--r--  1 sergii  staff    0 Aug 31 19:46 1-2-4-get-users-from-moco-warning.log
```
