### PR TITLE
Step 2: Match MoCo users to Northstar and generate new fields

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,11 @@
-NORTHSTAR_URL='https://northstar-thor.dosomething.org'
-NORTHSTAR_API_KEY='NorthstarKey'
+NORTHSTAR_URL=https://northstar-thor.dosomething.org
+NORTHSTAR_API_KEY=NorthstarKey
 
-MOCO_USERNAME='MobileCommonsUser'
-MOCO_PASSWORD='MobileCommonsPassword'
+MOCO_USERNAME=MobileCommonsUser
+MOCO_PASSWORD=MobileCommonsPassword
+
+# Generate your access token here: https://bitly.com/a/oauth_apps
+BITLY_ACCESS_TOKEN=your_bitly_key
 
 REDIS_HOST=127.0.0.1
 REDIS_PORT=6379

--- a/1-get-users-from-moco.php
+++ b/1-get-users-from-moco.php
@@ -128,4 +128,4 @@ if ($progress->getRegistry()->getValue('current') < $progressMax) {
   $progress->update($progressMax);
 }
 
-$redis->close();
+$redisRead->close();

--- a/2-generate-links.php
+++ b/2-generate-links.php
@@ -1,0 +1,76 @@
+<?php
+
+// --- Config ---
+require 'config.php';
+
+// ---  Options ---
+$opts = CLIOpts\CLIOpts::run("
+{self}
+-i, --iterator <int> Last iterator value
+-l, --last <int> Last current count
+");
+
+$args = (array) $opts;
+$iterator = !empty($args['iterator']) ? (int) $args['iterator'] : NULL;
+
+// --- Imports ---
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
+
+// --- Logger ---
+$logNamePrefix = REDIS_SCAN_COUNT
+ . '-' . ($iterator ?: 0)
+ . '-generate-links-';
+
+// File.
+$logfile = fopen(__DIR__ . '/log/' . $logNamePrefix . 'output.log', "w");
+$logFileStream = new StreamHandler($logfile);
+$logFileStream->setFormatter(new LineFormatter($output . "\n", $dateFormat));
+$log->pushHandler($logFileStream);
+// Warning File.
+$logfile = fopen(__DIR__ . '/log/' . $logNamePrefix . 'warning.log', "w");
+$logFileStream = new StreamHandler($logfile, Logger::WARNING);
+$logFileStream->setFormatter(new LineFormatter($output . "\n", $dateFormat));
+$log->pushHandler($logFileStream);
+
+// --- Progress ---
+$progressCurrent = !empty($args['last']) ? (int) $args['last'] : 0;
+$progressMax = $redis->dbSize();
+$progress = new \ProgressBar\Manager(0, $progressMax);
+$progress->update($progressCurrent);
+
+// --- Get data ---
+// Retry when we get no keys back.
+$redis->setOption(Redis::OPT_SCAN, Redis::SCAN_RETRY);
+while($keysBatch = $redis->scan($iterator, REDIS_KEY . ':*', REDIS_SCAN_COUNT)) {
+  foreach($keysBatch as $key) {
+    // Monitor progress.
+    try {
+      $progress->advance();
+    } catch (InvalidArgumentException $e) {
+      // Ignore current > max error.
+    } catch (Exception $e) {
+      // Log other errors.
+      $log->error($e);
+    }
+
+    $mocoUser = $redis->hGetAll($key);
+
+    $log->debug('{current} of {max}, iterator {it}: Processing #{phone}', [
+      'current' => $progress->getRegistry()->getValue('current'),
+      'max'     => $progress->getRegistry()->getValue('max'),
+      'it'      => $iterator,
+      'phone'   => $mocoUser['phone_number'],
+    ]);
+
+  }
+  // Process new batch.
+}
+
+// Set 100% when estimated $progressMax turned out to be incorrect.
+if ($progress->getRegistry()->getValue('current') < $progressMax) {
+  $progress->update($progressMax);
+}
+
+$redis->close();

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "deweller/cliopts": "^1.0",
     "josegonzalez/dotenv": "^2.0",
     "guiguiboy/php-cli-progress-bar": "@dev",
-    "nesbot/carbon": "^1.21"
+    "nesbot/carbon": "^1.21",
+    "hpatoio/bitly-api": "^2.0"
   },
   "autoload": {
     "psr-4": {

--- a/config.php
+++ b/config.php
@@ -44,11 +44,16 @@ $output = "[%datetime%] %level_name%: %message%.";
 
 
 // --- Objects ---
+// Northstar.
 $northstar = new NorthstarClient($northstar_config);
+// Mobile Commons
 $moco = new MobileCommonsLoader($moco_config, $log);
+// Bitly
+$bitly = new \Hpatoio\Bitly\Client(BITLY_ACCESS_TOKEN);
+// Redis
 $redis = new Redis();
 $redis->pconnect(REDIS_HOST, REDIS_PORT);
 $redisRead = new Redis();
 $redisRead->connect(REDIS_HOST, REDIS_PORT);
 define("REDIS_KEY", 'vcard:moco_users');
-define('REDIS_SCAN_COUNT', 2);
+define('REDIS_SCAN_COUNT', 100);

--- a/config.php
+++ b/config.php
@@ -48,5 +48,7 @@ $northstar = new NorthstarClient($northstar_config);
 $moco = new MobileCommonsLoader($moco_config, $log);
 $redis = new Redis();
 $redis->pconnect(REDIS_HOST, REDIS_PORT);
+$redisRead = new Redis();
+$redisRead->connect(REDIS_HOST, REDIS_PORT);
 define("REDIS_KEY", 'vcard:moco_users');
 define('REDIS_SCAN_COUNT', 2);

--- a/config.php
+++ b/config.php
@@ -49,3 +49,4 @@ $moco = new MobileCommonsLoader($moco_config, $log);
 $redis = new Redis();
 $redis->pconnect(REDIS_HOST, REDIS_PORT);
 define("REDIS_KEY", 'vcard:moco_users');
+define('REDIS_SCAN_COUNT', 2);

--- a/src/NorthstarLoader.php
+++ b/src/NorthstarLoader.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace DoSomething\Vcard;
+
+use DoSomething\Northstar\NorthstarClient;
+use DoSomething\Northstar\Resources\NorthstarUser;
+use Psr\Log\LoggerInterface;
+
+/**
+*
+*/
+class NorthstarLoader
+{
+
+  private $client = false;
+  private $log = false;
+  public $batchSize = 100;
+  public $sleep = 0;
+
+  function __construct(NorthstarClient $client, LoggerInterface $logger) {
+    $this->client = $client;
+    $this->log = $logger;
+  }
+
+  function loadFromMocoData(Array $mocoRedisUser) {
+    // Cleanup phone number.
+    // @see https://github.com/DoSomething/northstar/blob/dev/app/Models/User.php#L185
+    $phoneNumber = preg_replace('/[^0-9]/', '', $mocoRedisUser['phone_number']);
+
+    // First, load mobile number shortened version.
+    // Strip US +1 code from the beginning.
+    if (strlen($phoneNumber) === 11 && $phoneNumber[0] === '1') {
+      $shortenedPhoneNumber = substr($phoneNumber, 1);
+    }
+    $this->log->debug('Loading by shortened phone #{phone}', [
+      'phone'   => $shortenedPhoneNumber,
+    ]);
+    $northstarUser = $this->client->getUser('mobile', $shortenedPhoneNumber);
+    if ($northstarUser) {
+      return $northstarUser;
+    }
+
+    // Second, load by full phone number.
+    $this->log->debug('Loading by full phone #{phone}', [
+      'phone'   => $phoneNumber,
+    ]);
+    $northstarUser = $this->client->getUser('mobile', $phoneNumber);
+    if ($northstarUser) {
+      return $northstarUser;
+    }
+
+    // Third, try to load by email.
+    if (empty($mocoRedisUser['email'])) {
+      $this->log->warning('Can\'t load user #{phone}', [
+        'phone'   => $phoneNumber,
+      ]);
+      return false;
+    }
+
+    $this->log->debug('Loading by email {email}', [
+      'email' => $mocoRedisUser['email'],
+    ]);
+    $northstarUser = $this->client->getUser('mobile', $phoneNumber);
+    if ($northstarUser) {
+      return $northstarUser;
+    }
+    $this->log->warning('Can\'t load user #{phone}', [
+      'phone'   => $phoneNumber,
+    ]);
+    return false;
+  }
+
+}


### PR DESCRIPTION
Extends data from step 1 with northstar fields and bitly links.
### Step 2: Match MoCo users to Northstar and generate new fields

```
Usage:
  2-generate-links.php [options]

Options:
  -i, --iterator <int> Scan iterator value of last successfully saved batch. Works only with unchanged hashes
  -l, --last <int>     A number of last successfully saved element. Works only with unchanged hashes
  -u, --url <url>      Link base url. Defaults to https://www.dosomething.org/us/campaigns/lose-your-v-card
  -h, --help           Show this help
```

Normal usage is `php  2-generate-links.php`.
Iterator and last options are meant only for resuming work when script failed.

cc @aaronschachter @mshmsh5000 @DFurnes 
