### PR TITLE
Patch 9: Change progress bar library refactoring

### DIFF
--- a/2-generate-links.php
+++ b/2-generate-links.php
@@ -63,7 +63,7 @@ $northstarLoader = new NorthstarLoader($northstar, $log);
 $redisRead->setOption(Redis::OPT_SCAN, Redis::SCAN_RETRY);
 while($keysBatch = $redisRead->scan($iterator, REDIS_KEY . ':*', REDIS_SCAN_COUNT)) {
 
-  // Redis transcation.
+  // Initiate Redis transcation.
   $ret = $redis->multi();
 
   // Process batch.

--- a/2-generate-links.php
+++ b/2-generate-links.php
@@ -21,6 +21,7 @@ use Carbon\Carbon;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
+use Zend\ProgressBar\ProgressBar;
 
 // --- DS Imports ---
 use DoSomething\Vcard\NorthstarLoader;
@@ -46,10 +47,15 @@ $log->pushHandler($logFileStream);
 echo 'Logging to ' . $mainLogName . PHP_EOL;
 
 // --- Progress ---
-$progressCurrent = !empty($args['last']) ? (int) $args['last'] : 0;
-$progressMax = $redisRead->dbSize();
-$progress = new \ProgressBar\Manager(0, $progressMax);
-$progress->update($progressCurrent);
+$progressData = (object) [
+  'current' => !empty($args['last']) ? (int) $args['last'] : 0,
+  'max' => $redisRead->dbSize(),
+];
+$progress = new ProgressBar(
+  $progressAdapter,
+  $progressData->current,
+  $progressData->max
+);
 
 // --- Get data ---
 // Retry when we get no keys back.
@@ -64,20 +70,16 @@ while($keysBatch = $redisRead->scan($iterator, REDIS_KEY . ':*', REDIS_SCAN_COUN
   try {
     foreach($keysBatch as $key) {
       // Monitor progress.
-      try {
-        $progress->advance();
-      } catch (InvalidArgumentException $e) {
-        // Ignore current > max error.
-      } catch (Exception $e) {
-        // Log other errors.
-        $log->error($e);
-      }
+      $progress->update(
+        ++$progressData->current,
+        $progressData->current . '/' . $progressData->max
+      );
 
       // Load user from redis.
       $mocoRedisUser = $redisRead->hGetAll($key);
       $log->debug('{current} of {max}, iterator {it}: Loading user #{phone}, MoCo id {id}', [
-        'current' => $progress->getRegistry()->getValue('current'),
-        'max'     => $progress->getRegistry()->getValue('max'),
+        'current' => $progressData->current,
+        'max'     => $progressData->max,
         'it'      => $iterator,
         'phone'   => $mocoRedisUser['phone_number'],
         'id'      => $mocoRedisUser['id'],
@@ -144,8 +146,12 @@ while($keysBatch = $redisRead->scan($iterator, REDIS_KEY . ':*', REDIS_SCAN_COUN
 }
 
 // Set 100% when estimated $progressMax turned out to be incorrect.
-if ($progress->getRegistry()->getValue('current') < $progressMax) {
-  $progress->update($progressMax);
+if ($progressData->current < $progressData->max) {
+  $progress->update(
+    $progressData->max,
+    $progressData->max . '/' . $progressData->max
+  );
 }
+$progress->finish();
 
 $redisRead->close();

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "deweller/cliopts": "^1.0",
     "josegonzalez/dotenv": "^2.0",
     "nesbot/carbon": "^1.21",
-    "hpatoio/bitly-api": "^2.0"
+    "hpatoio/bitly-api": "^2.0",
+    "zendframework/zend-progressbar": "^2.5"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     "dosomething/mobilecommons-php": "^1.0",
     "deweller/cliopts": "^1.0",
     "josegonzalez/dotenv": "^2.0",
-    "guiguiboy/php-cli-progress-bar": "@dev",
     "nesbot/carbon": "^1.21",
     "hpatoio/bitly-api": "^2.0"
   },

--- a/config.php
+++ b/config.php
@@ -21,13 +21,13 @@ $moco_config = array(
 );
 
 // --- Imports ---
+use Monolog\Logger;
+use Monolog\Processor\PsrLogMessageProcessor;
+use Zend\ProgressBar\Adapter\Console as AdapterConsole;
+
+// --- DS Imports ---
 use DoSomething\Northstar\NorthstarClient;
 use DoSomething\Vcard\MobileCommonsLoader;
-use Monolog\Logger;
-// use Monolog\Handler\StreamHandler;
-// use Monolog\Handler\ErrorLogHandler;
-use Monolog\Processor\PsrLogMessageProcessor;
-// use Monolog\Formatter\LineFormatter;
 
 // --- Logger ---
 $log = new Logger('vcard');
@@ -57,3 +57,11 @@ $redisRead = new Redis();
 $redisRead->connect(REDIS_HOST, REDIS_PORT);
 define("REDIS_KEY", 'vcard:moco_users');
 define('REDIS_SCAN_COUNT', 100);
+// Zend Progress Bar
+$progressAdapter = new AdapterConsole();
+$progressAdapter->setElements([
+  AdapterConsole::ELEMENT_PERCENT,
+  AdapterConsole::ELEMENT_BAR,
+  AdapterConsole::ELEMENT_TEXT,
+  AdapterConsole::ELEMENT_ETA,
+]);


### PR DESCRIPTION
Use [`zendframework/zend-progressbar`](https://github.com/zendframework/zend-progressbar) instead of [`guiguiboy/php-cli-progress-bar`](https://github.com/guiguiboy/PHP-CLI-Progress-Bar).

Closes #9.
