### PR TITLE
Major bugfixes: pagination and memory leak

### DIFF
--- a/1-get-users-from-moco.php
+++ b/1-get-users-from-moco.php
@@ -93,6 +93,11 @@ $progress = new ProgressBar(
 
 // --- Get data ---
 while ($profiles = $moco->profilesEachBatch($progressData->page++, $argLastPage)) {
+  // var_dump(
+  //   round(memory_get_usage()/1048576,2)." megabytes",
+  //   round(memory_get_usage(true)/1048576,2)." megabytes"
+  // );
+
   // Initiate Redis transcation.
   $ret = $redis->multi();
   try {
@@ -157,6 +162,9 @@ while ($profiles = $moco->profilesEachBatch($progressData->page++, $argLastPage)
     $ret->discard();
     throw $e;
   }
+
+  // Force garbage collector.
+  gc_collect_cycles();
 }
 
 // Set 100% when estimated $progressMax turned out to be incorrect.

--- a/2-generate-links.php
+++ b/2-generate-links.php
@@ -142,7 +142,8 @@ while($keysBatch = $redisRead->scan($iterator, REDIS_KEY . ':*', REDIS_SCAN_COUN
     throw $e;
   }
 
-
+  // Force garbage collector.
+  gc_collect_cycles();
 }
 
 // Set 100% when estimated $progressMax turned out to be incorrect.

--- a/config.php
+++ b/config.php
@@ -1,5 +1,8 @@
 <?php
 
+// PHP settings.
+gc_enable();
+
 // --- Composer ---
 require __DIR__ . '/vendor/autoload.php';
 

--- a/src/MobileCommonsLoader.php
+++ b/src/MobileCommonsLoader.php
@@ -20,7 +20,11 @@ class MobileCommonsLoader
     $this->log = $logger;
   }
 
-  function profilesEachBatch($callback, $page = 1, $limit = 0) {
+  function profilesEachBatch($page = 1, $limit = 0) {
+    // Exit on out of bounds.
+    if ($limit != 0 && $page > $limit) {
+      return false;
+    }
     $this->log->debug(
       'Loading profiles from MoCo, batch size {size}, page {page}',
       [
@@ -46,18 +50,15 @@ class MobileCommonsLoader
       return ($page > 1);
     }
 
-    $profiles = $response->profiles;
-    $numReturned = (int) $profiles->profile->count();
-
-    $callback($profiles);
-
     if ($this->sleep > 0) {
       sleep($this->sleep);
     }
 
-    if ($limit == 0 || $page < $limit) {
-      return $this->profilesEachBatch($callback, $page + 1, $limit);
+    $profiles = $response->profiles;
+    if ($profiles) {
+      return $profiles;
     }
+    return false;
   }
 
 }


### PR DESCRIPTION
- Fix pagination errors by rethinking whole system
- Alleged fix of memory leak
- Force garbage collector

See issue #9. Turned out it's not related to progress bar. There is a memory leak so `1-get-users-from-moco.php` eats up all memory:

Script is running, numbers in gigabytes:

```
sergii@ip-10-100-35-14:~/scripts/vcard-scripts$ free -g
             total       used       free     shared    buffers     cached
Mem:            15         14          1          0          0          0
-/+ buffers/cache:         13          1
Swap:            0          0          0
```

Script is stopped, numbers in gigabytes:

```
sergii@ip-10-100-35-14:~/scripts/vcard-scripts$ free -g
             total       used       free     shared    buffers     cached
Mem:            15          0         15          0          0          0
-/+ buffers/cache:          0         15
Swap:            0          0          0
```

I think I fixed it by refactoring `profilesEachBatch()` from recursive function to `while(profilesEachBatch()) {}` loop.

Script `php 1-get-users-from-moco.php -l 100 -b 1` before refactoring used up `3.5 megabytes` on first iteration and `4 megabytes` on last.
After: `3.5 megabytes` on first and `3.75 megabytes` on last.
The change is not significant, but i think it'll add up on larger batches.

cc @mshmsh5000 @aaronschachter 
