### PR TITLE
Save profiles: improve code.

### DIFF
--- a/2-generate-links.php
+++ b/2-generate-links.php
@@ -134,7 +134,7 @@ while($keysBatch = $redisRead->scan($iterator, REDIS_KEY . ':*', REDIS_SCAN_COUN
         }
       }
 
-      $ret->hSet($key, 'northstar_processed', 1);
+      $ret->hSet($key, 'step2_status', 1);
     }
 
     // Batch processed.


### PR DESCRIPTION
- Process step 3 only if when processed by step 2
- Assign birthdays and Northstar id only when user has been matched with Northstar user
