### PR TITLE
Remove bitly integration from steps 2 and 3.

### DIFF
--- a/2-generate-links.php
+++ b/2-generate-links.php
@@ -119,20 +119,20 @@ while($keysBatch = $redisRead->scan($iterator, REDIS_KEY . ':*', REDIS_SCAN_COUN
       }
 
 
-      if (empty($mocoRedisUser['vcard_share_url_id']) || $linkUpdated) {
-        $log->debug('Generating bitly link for {link}', [
-          'link'   => $link,
-        ]);
-        $bitlyLink = $bitly->Shorten(["longUrl" => $link]);
-        if (!empty($bitlyLink['url'])) {
-          $shortenedLink = $bitlyLink['url'];
-          $log->debug('Shortened link for {link} is {shortened_link}', [
-            'link'           => $link,
-            'shortened_link' => $shortenedLink,
-          ]);
-          $ret->hSet($key, 'vcard_share_url_id', $shortenedLink);
-        }
-      }
+      // if (empty($mocoRedisUser['vcard_share_url_id']) || $linkUpdated) {
+      //   $log->debug('Generating bitly link for {link}', [
+      //     'link'   => $link,
+      //   ]);
+      //   $bitlyLink = $bitly->Shorten(["longUrl" => $link]);
+      //   if (!empty($bitlyLink['url'])) {
+      //     $shortenedLink = $bitlyLink['url'];
+      //     $log->debug('Shortened link for {link} is {shortened_link}', [
+      //       'link'           => $link,
+      //       'shortened_link' => $shortenedLink,
+      //     ]);
+      //     $ret->hSet($key, 'vcard_share_url_id', $shortenedLink);
+      //   }
+      // }
 
       $ret->hSet($key, 'step2_status', 1);
     }

--- a/3-save-profile-updates-to-moco.php
+++ b/3-save-profile-updates-to-moco.php
@@ -91,7 +91,8 @@ while($keysBatch = $redisRead->scan($iterator, REDIS_KEY . ':*', REDIS_SCAN_COUN
 
       $mocoProfileUpdate = [
         'phone_number'       => $mocoRedisUser['phone_number'],
-        'vcard_share_url_id' => $mocoRedisUser['vcard_share_url_id'],
+        // 'vcard_share_url_id' => $mocoRedisUser['vcard_share_url_id'],
+        'vcard_share_url_full' => $mocoRedisUser['vcard_share_url_full'],
       ];
       if (!empty($mocoRedisUser['northstar_id'])) {
         $mocoProfileUpdate['northstar_id']  = $mocoRedisUser['northstar_id'];

--- a/config.php
+++ b/config.php
@@ -68,7 +68,7 @@ $northstar = new NorthstarClient($northstar_config);
 // Mobile Commons
 $moco = new MobileCommonsLoader($moco_config, $log);
 // Bitly
-$bitly = new \Hpatoio\Bitly\Client(BITLY_ACCESS_TOKEN);
+// $bitly = new \Hpatoio\Bitly\Client(BITLY_ACCESS_TOKEN);
 // Redis
 $redis = new Redis();
 $redis->pconnect(REDIS_HOST, REDIS_PORT);


### PR DESCRIPTION
Turn off bitly integration until we reach and agreement on API calls limits or use another service.
Save full link instead.
