### PR TITLE
Fix error in Northstar loader.

### DIFF
--- a/src/NorthstarLoader.php
+++ b/src/NorthstarLoader.php
@@ -31,13 +31,13 @@ class NorthstarLoader
     // Strip US +1 code from the beginning.
     if (strlen($phoneNumber) === 11 && $phoneNumber[0] === '1') {
       $shortenedPhoneNumber = substr($phoneNumber, 1);
-    }
-    $this->log->debug('Loading by shortened phone #{phone}', [
-      'phone'   => $shortenedPhoneNumber,
-    ]);
-    $northstarUser = $this->client->getUser('mobile', $shortenedPhoneNumber);
-    if ($northstarUser) {
-      return $northstarUser;
+      $this->log->debug('Loading by shortened phone #{phone}', [
+        'phone'   => $shortenedPhoneNumber,
+      ]);
+      $northstarUser = $this->client->getUser('mobile', $shortenedPhoneNumber);
+      if ($northstarUser) {
+        return $northstarUser;
+      }
     }
 
     // Second, load by full phone number.


### PR DESCRIPTION
Shorten phone number call must only be executed when the number actually falls into this category.

Error produced:

```
PHP Notice:  Undefined variable: shortenedPhoneNumber in /home/sergii/scripts/vcard-scripts/src/NorthstarLoader.php on line 36
PHP Notice:  Undefined variable: shortenedPhoneNumber in /home/sergii/scripts/vcard-scripts/src/NorthstarLoader.php on line 38
PHP Fatal error:  Uncaught DoSomething\Northstar\Exceptions\InternalException: Exception in Northstar "GET users/mobile/" endpoint: [405] Client error response [url] https://northstar-thor.dosomething.org/v1/users/mobile [status code] 405 [reason phrase] Method Not Allowed in /home/sergii/scripts/vcard-scripts/vendor/dosomething/northstar/src/Common/RestAPIClient.php:143
Stack trace:
#0 /home/sergii/scripts/vcard-scripts/vendor/dosomething/northstar/src/Common/RestAPIClient.php(50): DoSomething\Northstar\Common\RestAPIClient->send('GET', 'users/mobile/', Array)
#1 /home/sergii/scripts/vcard-scripts/vendor/dosomething/northstar/src/NorthstarClient.php(71): DoSomething\Northstar\Common\RestAPIClient->get('users/mobile/')
#2 /home/sergii/scripts/vcard-scripts/src/NorthstarLoader.php(38): DoSomething\Northstar\NorthstarClient->getUser('mobile', NULL)
#3 /home/sergii/scripts/vcard-scripts/2-generate-links.php(89): DoSomething\Vcard\NorthstarLoader->loadFromMocoData(Array)
#4 {main}
  thrown in /home/sergii/scripts/vcard-scripts/vendor/dosomething/northstar/src/Common/RestAPIClient.php on line 143
```
