### PR TITLE
Wrap vcard_share_url_full in parentesses to force its shortening.

### DIFF
--- a/3-save-profile-updates-to-moco.php
+++ b/3-save-profile-updates-to-moco.php
@@ -124,8 +124,8 @@ for (;$progressData->current <= $progressData->max; $progressData->current++) {
 
     $mocoProfileUpdate = [
       'phone_number'       => $mocoRedisUser['phone_number'],
-      // 'vcard_share_url_id' => $mocoRedisUser['vcard_share_url_id'],
-      'vcard_share_url_full' => $mocoRedisUser['vcard_share_url_full'],
+      // Wrapping URL in parentesses tells Liquid to automatically shorten it.
+      'vcard_share_url_full' => '((' . $mocoRedisUser['vcard_share_url_full'] . '))',
     ];
     if (!empty($mocoRedisUser['northstar_id'])) {
       $mocoProfileUpdate['northstar_id']  = $mocoRedisUser['northstar_id'];


### PR DESCRIPTION
Support new functionality on MoCo.
It is possible shorten saved in variable with wrapping its value in double parentheses.

Example:
<img width="810" alt="screen shot 2016-09-06 at 11 53 37 am" src="https://cloud.githubusercontent.com/assets/672669/18288447/1963b498-7484-11e6-9c3e-e66fedfdc61a.png">
